### PR TITLE
fix(transformLinkToUnfurledNode): add missing closing parenthesis

### DIFF
--- a/transformLinkToUnfurledNode.ts
+++ b/transformLinkToUnfurledNode.ts
@@ -4,7 +4,7 @@ import * as mustache from 'mustache'
 export const tranformsLinkNodeToUnfurledNode = (node: Node, card: MetadataInterface) => {
   node.type = 'html'
   const template = `<a class='gatsby-remark-link-unfurl__container' href='{{card.url}}' target='_blank' title='{{card.title}}'>
-    <div class='gatsby-remark-link-unfurl__media' style='background-image: url({{card.image.url}}'></div>
+    <div class='gatsby-remark-link-unfurl__media' style='background-image: url({{card.image.url}})'></div>
     <div class='gatsby-remark-link-unfurl__content'>
       <header class='gatsby-remark-link-unfurl__title'><p  title='{{card.title}}'>{{card.title}}</p></header>
       <div class='gatsby-remark-link-unfurl__description'><p title='{{card.description}}'>{{card.description}}</p></div>


### PR DESCRIPTION
This microscopic PR is to fix the missing closing parenthesis for the `background-image`. 